### PR TITLE
chore(ci): add android build delivery 

### DIFF
--- a/.github/workflows/_android-build.yml
+++ b/.github/workflows/_android-build.yml
@@ -1,0 +1,344 @@
+name: Reusable Android Build
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+        default: ""
+      build_name:
+        required: true
+        type: string
+      build_profile:
+        required: true
+        type: string
+      artifact_extension:
+        required: true
+        type: string
+      artifact_subdir:
+        required: true
+        type: string
+      generate_signed_url:
+        required: false
+        type: boolean
+        default: false
+      gcs_bucket:
+        required: true
+        type: string
+      gcs_prefix:
+        required: false
+        type: string
+        default: "mobile-builds"
+      gcs_signed_url_duration:
+        required: false
+        type: string
+        default: "12h"
+      gcp_workload_identity_provider:
+        required: true
+        type: string
+      gcp_service_account:
+        required: true
+        type: string
+      gcp_project_id:
+        required: false
+        type: string
+        default: ""
+      expo_public_debug_logs:
+        required: false
+        type: string
+        default: ""
+    secrets:
+      EXPO_TOKEN:
+        required: true
+      EXPO_PROJECT_ID:
+        required: true
+      EXPO_PUBLIC_API_BASE_URL:
+        required: true
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID:
+        required: true
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS:
+        required: true
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID:
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build ${{ inputs.build_name }} on EAS
+    runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
+      EXPO_PUBLIC_API_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_BASE_URL }}
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID }}
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS }}
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID }}
+      EXPO_PUBLIC_DEBUG_LOGS: ${{ inputs.expo_public_debug_logs }}
+      GCS_BUCKET: ${{ inputs.gcs_bucket }}
+      GCS_PREFIX: ${{ inputs.gcs_prefix }}
+      GCS_SIGNED_URL_DURATION: ${{ inputs.gcs_signed_url_duration }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ inputs.gcp_workload_identity_provider }}
+      GCP_SERVICE_ACCOUNT: ${{ inputs.gcp_service_account }}
+      GCP_PROJECT_ID: ${{ inputs.gcp_project_id }}
+    steps:
+      - name: Check required configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+
+          for name in \
+            EXPO_TOKEN \
+            EXPO_PROJECT_ID \
+            EXPO_PUBLIC_API_BASE_URL \
+            EXPO_PUBLIC_GOOGLE_CLIENT_ID \
+            EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS \
+            EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error title=Missing secret::GitHub Actions secret '$name' is required."
+              missing=1
+            fi
+          done
+
+          for name in \
+            GCS_BUCKET \
+            GCP_WORKLOAD_IDENTITY_PROVIDER \
+            GCP_SERVICE_ACCOUNT
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error title=Missing variable::GitHub Actions variable '$name' is required."
+              missing=1
+            fi
+          done
+
+          if [ "$missing" -ne 0 ]; then
+            echo "Missing one or more required GitHub Actions secrets or variables." >&2
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: 18.4.0
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve build context
+        id: context
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "requested_ref=${{ inputs.ref || github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "app_version=$(node -p "require('./app.json').expo.version")" >> "$GITHUB_OUTPUT"
+          echo "build_timestamp=$(date -u +%Y%m%dT%H%M%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Expo config for CI
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const loadConfig = require("./app.config.js");
+          const config = typeof loadConfig === "function" ? loadConfig() : loadConfig;
+          const projectId = config?.extra?.eas?.projectId;
+
+          if (!projectId) {
+            console.error(
+              "Missing EAS project ID. Set EXPO_PROJECT_ID in GitHub Secrets or expo.extra.eas.projectId in Expo config."
+            );
+            process.exit(1);
+          }
+
+          console.log(`Using EAS project ID: ${projectId}`);
+          NODE
+
+      - name: Trigger EAS Android build
+        id: eas_build
+        shell: bash
+        run: |
+          set -euo pipefail
+          build_json="$RUNNER_TEMP/eas-build-${{ inputs.artifact_extension }}.json"
+
+          eas build \
+            --platform android \
+            --profile "${{ inputs.build_profile }}" \
+            --non-interactive \
+            --wait \
+            --json \
+            > "$build_json"
+
+          node - "$build_json" "$GITHUB_OUTPUT" <<'NODE'
+          const fs = require("fs");
+          const [jsonPath, outputPath] = process.argv.slice(2);
+          const raw = fs.readFileSync(jsonPath, "utf8").trim();
+
+          if (!raw) {
+            throw new Error("EAS build returned empty JSON output.");
+          }
+
+          const parsed = JSON.parse(raw);
+          const build = Array.isArray(parsed) ? parsed[0] : parsed;
+          const buildId = build?.id;
+          const detailsUrl = build?.buildDetailsPageUrl ?? "";
+          const artifactUrl =
+            build?.artifacts?.buildUrl ??
+            build?.artifacts?.applicationArchiveUrl ??
+            "";
+
+          if (!buildId) {
+            throw new Error(`Could not determine build ID from EAS output: ${raw}`);
+          }
+
+          if (!artifactUrl) {
+            throw new Error(`Could not determine artifact URL for build ${buildId}.`);
+          }
+
+          fs.appendFileSync(outputPath, `build_id=${buildId}\n`);
+          fs.appendFileSync(outputPath, `details_url=${detailsUrl}\n`);
+          fs.appendFileSync(outputPath, `artifact_url=${artifactUrl}\n`);
+          NODE
+
+      - name: Download build artifact
+        shell: bash
+        env:
+          ARTIFACT_URL: ${{ steps.eas_build.outputs.artifact_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          curl -fsSL "$ARTIFACT_URL" -o "dist/vendor-map-app.${{ inputs.artifact_extension }}"
+
+      - name: Prepare GCS object metadata
+        id: gcs_meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ref_slug="$(printf '%s' "${{ steps.context.outputs.requested_ref }}" | tr '/:@ ' '-' | tr -cd '[:alnum:]._-')"
+          if [ -z "$ref_slug" ]; then
+            ref_slug="manual"
+          fi
+
+          prefix="${GCS_PREFIX:-mobile-builds}"
+          prefix="${prefix#/}"
+          prefix="${prefix%/}"
+
+          artifact_file="vendor-map-app-${{ steps.context.outputs.app_version }}-${ref_slug}-${{ steps.context.outputs.short_sha }}-${{ steps.context.outputs.build_timestamp }}.${{ inputs.artifact_extension }}"
+          object_path="android/${{ inputs.artifact_subdir }}/${{ steps.context.outputs.app_version }}/${artifact_file}"
+
+          if [ -n "$prefix" ]; then
+            object_path="${prefix}/${object_path}"
+          fi
+
+          echo "artifact_file=$artifact_file" >> "$GITHUB_OUTPUT"
+          echo "object_path=$object_path" >> "$GITHUB_OUTPUT"
+          echo "gs_uri=gs://${GCS_BUCKET}/${object_path}" >> "$GITHUB_OUTPUT"
+          echo "signed_url_duration=${GCS_SIGNED_URL_DURATION:-12h}" >> "$GITHUB_OUTPUT"
+          echo "signed_url_artifact=android-${{ inputs.artifact_subdir }}-signed-url-${{ steps.context.outputs.commit_sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ inputs.gcp_workload_identity_provider }}
+          service_account: ${{ inputs.gcp_service_account }}
+          project_id: ${{ inputs.gcp_project_id }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          version: ">= 416.0.0"
+
+      - name: Upload build to GCS
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud storage cp "dist/vendor-map-app.${{ inputs.artifact_extension }}" "${{ steps.gcs_meta.outputs.gs_uri }}"
+
+      - name: Generate signed download URL
+        id: gcs_signed_url
+        shell: bash
+        env:
+          GENERATE_SIGNED_URL: ${{ inputs.generate_signed_url }}
+        run: |
+          # Deliberately omit `-e` here so a sign-url failure can be downgraded to a
+          # warning while preserving the successful build and GCS upload.
+          set -uo pipefail
+
+          if [ "$GENERATE_SIGNED_URL" != "true" ]; then
+            echo "status=skipped" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          tmp_err="$RUNNER_TEMP/gcs-sign-url.err"
+          if signed_url="$(
+            gcloud storage sign-url "${{ steps.gcs_meta.outputs.gs_uri }}" \
+              --duration="${{ steps.gcs_meta.outputs.signed_url_duration }}" \
+              --format='value(signed_url)' \
+              2>"$tmp_err"
+          )"; then
+            printf '%s\n' "$signed_url" > dist/download-url.txt
+            echo "status=generated" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            echo "Sign-url generation failed. Verify the service account can sign blobs (roles/iam.serviceAccountTokenCreator / iam.serviceAccounts.signBlob)." >&2
+            cat "$tmp_err" >&2
+          fi
+
+      - name: Upload signed URL artifact
+        if: steps.gcs_signed_url.outputs.status == 'generated'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.gcs_meta.outputs.signed_url_artifact }}
+          path: dist/download-url.txt
+          if-no-files-found: error
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-${{ inputs.artifact_subdir }}-${{ steps.context.outputs.commit_sha }}
+          path: dist/vendor-map-app.${{ inputs.artifact_extension }}
+          if-no-files-found: error
+
+      - name: Write job summary
+        shell: bash
+        env:
+          SIGNED_URL_STATUS: ${{ steps.gcs_signed_url.outputs.status }}
+        run: |
+          {
+            echo "## Android ${{ inputs.build_name }} build"
+            echo ""
+            echo "- Profile: \`${{ inputs.build_profile }}\`"
+            echo "- Requested ref: \`${{ inputs.ref || github.ref_name }}\`"
+            echo "- Checked out commit: \`${{ steps.context.outputs.commit_sha }}\`"
+            echo "- App version: \`${{ steps.context.outputs.app_version }}\`"
+            echo "- EAS build ID: \`${{ steps.eas_build.outputs.build_id }}\`"
+            echo "- EAS build details: ${{ steps.eas_build.outputs.details_url }}"
+            echo "- GitHub artifact: \`android-${{ inputs.artifact_subdir }}-${{ steps.context.outputs.commit_sha }}\`"
+            echo "- GCS object: \`${{ steps.gcs_meta.outputs.gs_uri }}\`"
+
+            if [ "$SIGNED_URL_STATUS" = "generated" ]; then
+              echo "- Signed URL: generated in artifact \`${{ steps.gcs_meta.outputs.signed_url_artifact }}\`"
+            elif [ "$SIGNED_URL_STATUS" = "failed" ]; then
+              echo "- Signed URL: generation failed. Check the workflow log and verify \`roles/iam.serviceAccountTokenCreator\`."
+            else
+              echo "- Signed URL: not generated. Re-run the workflow with \`generate_signed_url=true\` if needed."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-android-aab.yml
+++ b/.github/workflows/build-android-aab.yml
@@ -1,0 +1,258 @@
+name: Build Android AAB
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build. Leave blank to use the selected branch or tag."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build AAB on EAS
+    runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
+      EXPO_PUBLIC_API_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_BASE_URL }}
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID }}
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS }}
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID }}
+      EXPO_PUBLIC_DEBUG_LOGS: ${{ secrets.EXPO_PUBLIC_DEBUG_LOGS }}
+      GCS_BUCKET: ${{ vars.GCS_BUCKET }}
+      GCS_PREFIX: ${{ vars.GCS_PREFIX }}
+      GCS_SIGNED_URL_DURATION: ${{ vars.GCS_SIGNED_URL_DURATION }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+    steps:
+      - name: Check required GitHub secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+
+          for name in \
+            EXPO_TOKEN \
+            EXPO_PROJECT_ID \
+            EXPO_PUBLIC_API_BASE_URL \
+            EXPO_PUBLIC_GOOGLE_CLIENT_ID \
+            EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS \
+            EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error title=Missing secret::GitHub Actions secret '$name' is required."
+              missing=1
+            fi
+          done
+
+          if [ -z "${GCS_BUCKET:-}" ]; then
+            echo "::error title=Missing variable::GitHub Actions variable 'GCS_BUCKET' is required."
+            missing=1
+          fi
+
+          if [ -z "${GCP_WORKLOAD_IDENTITY_PROVIDER:-}" ]; then
+            echo "::error title=Missing variable::GitHub Actions variable 'GCP_WORKLOAD_IDENTITY_PROVIDER' is required."
+            missing=1
+          fi
+
+          if [ -z "${GCP_SERVICE_ACCOUNT:-}" ]; then
+            echo "::error title=Missing variable::GitHub Actions variable 'GCP_SERVICE_ACCOUNT' is required."
+            missing=1
+          fi
+
+          if [ "$missing" -ne 0 ]; then
+            echo "Missing one or more required GitHub Actions secrets or variables." >&2
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve build context
+        id: context
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "requested_ref=${{ inputs.ref || github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "app_version=$(node -p "require('./app.json').expo.version")" >> "$GITHUB_OUTPUT"
+          echo "build_timestamp=$(date -u +%Y%m%dT%H%M%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Expo config for CI
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const loadConfig = require("./app.config.js");
+          const config = typeof loadConfig === "function" ? loadConfig() : loadConfig;
+          const projectId = config?.extra?.eas?.projectId;
+
+          if (!projectId) {
+            console.error(
+              "Missing EAS project ID. Set EXPO_PROJECT_ID in GitHub Secrets or expo.extra.eas.projectId in Expo config."
+            );
+            process.exit(1);
+          }
+
+          console.log(`Using EAS project ID: ${projectId}`);
+          NODE
+
+      - name: Trigger EAS Android AAB build
+        id: eas_build
+        shell: bash
+        run: |
+          set -euo pipefail
+          build_json="$RUNNER_TEMP/eas-build-aab.json"
+
+          eas build \
+            --platform android \
+            --profile production-aab \
+            --non-interactive \
+            --wait \
+            --json \
+            > "$build_json"
+
+          node - "$build_json" "$GITHUB_OUTPUT" <<'NODE'
+          const fs = require("fs");
+          const [jsonPath, outputPath] = process.argv.slice(2);
+          const raw = fs.readFileSync(jsonPath, "utf8").trim();
+
+          if (!raw) {
+            throw new Error("EAS build returned empty JSON output.");
+          }
+
+          const parsed = JSON.parse(raw);
+          const build = Array.isArray(parsed) ? parsed[0] : parsed;
+          const buildId = build?.id;
+          const detailsUrl = build?.buildDetailsPageUrl ?? "";
+          const artifactUrl =
+            build?.artifacts?.buildUrl ??
+            build?.artifacts?.applicationArchiveUrl ??
+            "";
+
+          if (!buildId) {
+            throw new Error(`Could not determine build ID from EAS output: ${raw}`);
+          }
+
+          if (!artifactUrl) {
+            throw new Error(`Could not determine artifact URL for build ${buildId}.`);
+          }
+
+          fs.appendFileSync(outputPath, `build_id=${buildId}\n`);
+          fs.appendFileSync(outputPath, `details_url=${detailsUrl}\n`);
+          fs.appendFileSync(outputPath, `artifact_url=${artifactUrl}\n`);
+          NODE
+
+      - name: Download AAB artifact
+        shell: bash
+        env:
+          ARTIFACT_URL: ${{ steps.eas_build.outputs.artifact_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          curl -fsSL "$ARTIFACT_URL" -o dist/vendor-map-app.aab
+
+      - name: Prepare GCS object metadata
+        id: gcs_meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ref_slug="$(printf '%s' "${{ steps.context.outputs.requested_ref }}" | tr '/:@ ' '-' | tr -cd '[:alnum:]._-')"
+          if [ -z "$ref_slug" ]; then
+            ref_slug="manual"
+          fi
+
+          prefix="${GCS_PREFIX:-mobile-builds}"
+          prefix="${prefix#/}"
+          prefix="${prefix%/}"
+
+          artifact_file="vendor-map-app-${{ steps.context.outputs.app_version }}-${ref_slug}-${{ steps.context.outputs.short_sha }}-${{ steps.context.outputs.build_timestamp }}.aab"
+          object_path="android/aab/${{ steps.context.outputs.app_version }}/${artifact_file}"
+
+          if [ -n "$prefix" ]; then
+            object_path="${prefix}/${object_path}"
+          fi
+
+          echo "artifact_file=$artifact_file" >> "$GITHUB_OUTPUT"
+          echo "object_path=$object_path" >> "$GITHUB_OUTPUT"
+          echo "gs_uri=gs://${GCS_BUCKET}/${object_path}" >> "$GITHUB_OUTPUT"
+          echo "signed_url_duration=${GCS_SIGNED_URL_DURATION:-12h}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          version: ">= 416.0.0"
+
+      - name: Upload AAB to GCS
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud storage cp dist/vendor-map-app.aab "${{ steps.gcs_meta.outputs.gs_uri }}"
+
+      - name: Generate signed download URL
+        id: gcs_signed_url
+        shell: bash
+        run: |
+          set -euo pipefail
+          signed_url="$(
+            gcloud storage sign-url "${{ steps.gcs_meta.outputs.gs_uri }}" \
+              --duration="${{ steps.gcs_meta.outputs.signed_url_duration }}" \
+              --format='value(signed_url)'
+          )"
+          echo "signed_url=$signed_url" >> "$GITHUB_OUTPUT"
+
+      - name: Upload AAB artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-aab-${{ steps.context.outputs.commit_sha }}
+          path: dist/vendor-map-app.aab
+          if-no-files-found: error
+
+      - name: Write job summary
+        shell: bash
+        run: |
+          {
+            echo "## Android AAB build"
+            echo ""
+            echo "- Profile: \`production-aab\`"
+            echo "- Requested ref: \`${{ inputs.ref || github.ref_name }}\`"
+            echo "- Checked out commit: \`${{ steps.context.outputs.commit_sha }}\`"
+            echo "- App version: \`${{ steps.context.outputs.app_version }}\`"
+            echo "- EAS build ID: \`${{ steps.eas_build.outputs.build_id }}\`"
+            echo "- EAS build details: ${{ steps.eas_build.outputs.details_url }}"
+            echo "- GitHub artifact: \`android-aab-${{ steps.context.outputs.commit_sha }}\`"
+            echo "- GCS object: \`${{ steps.gcs_meta.outputs.gs_uri }}\`"
+            echo "- Signed URL (${{ steps.gcs_meta.outputs.signed_url_duration }}): ${{ steps.gcs_signed_url.outputs.signed_url }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-android-aab.yml
+++ b/.github/workflows/build-android-aab.yml
@@ -7,252 +7,33 @@ on:
         description: "Git ref to build. Leave blank to use the selected branch or tag."
         required: false
         type: string
-
-permissions:
-  contents: read
-  id-token: write
+      generate_signed_url:
+        description: "Generate a signed download URL artifact. The URL will not be written to the job summary."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
-    name: Build AAB on EAS
-    runs-on: ubuntu-latest
-    env:
+    uses: ./.github/workflows/_android-build.yml
+    with:
+      ref: ${{ inputs.ref }}
+      build_name: AAB
+      build_profile: production-aab
+      artifact_extension: aab
+      artifact_subdir: aab
+      generate_signed_url: ${{ inputs.generate_signed_url }}
+      gcs_bucket: ${{ vars.GCS_BUCKET }}
+      gcs_prefix: ${{ vars.GCS_PREFIX }}
+      gcs_signed_url_duration: ${{ vars.GCS_SIGNED_URL_DURATION }}
+      gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+      expo_public_debug_logs: ${{ vars.EXPO_PUBLIC_DEBUG_LOGS }}
+    secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
       EXPO_PUBLIC_API_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_BASE_URL }}
       EXPO_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID }}
       EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS }}
       EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID }}
-      EXPO_PUBLIC_DEBUG_LOGS: ${{ secrets.EXPO_PUBLIC_DEBUG_LOGS }}
-      GCS_BUCKET: ${{ vars.GCS_BUCKET }}
-      GCS_PREFIX: ${{ vars.GCS_PREFIX }}
-      GCS_SIGNED_URL_DURATION: ${{ vars.GCS_SIGNED_URL_DURATION }}
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
-      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-    steps:
-      - name: Check required GitHub secrets
-        shell: bash
-        run: |
-          set -euo pipefail
-          missing=0
-
-          for name in \
-            EXPO_TOKEN \
-            EXPO_PROJECT_ID \
-            EXPO_PUBLIC_API_BASE_URL \
-            EXPO_PUBLIC_GOOGLE_CLIENT_ID \
-            EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS \
-            EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID
-          do
-            if [ -z "${!name:-}" ]; then
-              echo "::error title=Missing secret::GitHub Actions secret '$name' is required."
-              missing=1
-            fi
-          done
-
-          if [ -z "${GCS_BUCKET:-}" ]; then
-            echo "::error title=Missing variable::GitHub Actions variable 'GCS_BUCKET' is required."
-            missing=1
-          fi
-
-          if [ -z "${GCP_WORKLOAD_IDENTITY_PROVIDER:-}" ]; then
-            echo "::error title=Missing variable::GitHub Actions variable 'GCP_WORKLOAD_IDENTITY_PROVIDER' is required."
-            missing=1
-          fi
-
-          if [ -z "${GCP_SERVICE_ACCOUNT:-}" ]; then
-            echo "::error title=Missing variable::GitHub Actions variable 'GCP_SERVICE_ACCOUNT' is required."
-            missing=1
-          fi
-
-          if [ "$missing" -ne 0 ]; then
-            echo "Missing one or more required GitHub Actions secrets or variables." >&2
-            exit 1
-          fi
-
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Setup Expo and EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Resolve build context
-        id: context
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-          echo "requested_ref=${{ inputs.ref || github.ref_name }}" >> "$GITHUB_OUTPUT"
-          echo "app_version=$(node -p "require('./app.json').expo.version")" >> "$GITHUB_OUTPUT"
-          echo "build_timestamp=$(date -u +%Y%m%dT%H%M%SZ)" >> "$GITHUB_OUTPUT"
-
-      - name: Validate Expo config for CI
-        shell: bash
-        run: |
-          set -euo pipefail
-          node - <<'NODE'
-          const loadConfig = require("./app.config.js");
-          const config = typeof loadConfig === "function" ? loadConfig() : loadConfig;
-          const projectId = config?.extra?.eas?.projectId;
-
-          if (!projectId) {
-            console.error(
-              "Missing EAS project ID. Set EXPO_PROJECT_ID in GitHub Secrets or expo.extra.eas.projectId in Expo config."
-            );
-            process.exit(1);
-          }
-
-          console.log(`Using EAS project ID: ${projectId}`);
-          NODE
-
-      - name: Trigger EAS Android AAB build
-        id: eas_build
-        shell: bash
-        run: |
-          set -euo pipefail
-          build_json="$RUNNER_TEMP/eas-build-aab.json"
-
-          eas build \
-            --platform android \
-            --profile production-aab \
-            --non-interactive \
-            --wait \
-            --json \
-            > "$build_json"
-
-          node - "$build_json" "$GITHUB_OUTPUT" <<'NODE'
-          const fs = require("fs");
-          const [jsonPath, outputPath] = process.argv.slice(2);
-          const raw = fs.readFileSync(jsonPath, "utf8").trim();
-
-          if (!raw) {
-            throw new Error("EAS build returned empty JSON output.");
-          }
-
-          const parsed = JSON.parse(raw);
-          const build = Array.isArray(parsed) ? parsed[0] : parsed;
-          const buildId = build?.id;
-          const detailsUrl = build?.buildDetailsPageUrl ?? "";
-          const artifactUrl =
-            build?.artifacts?.buildUrl ??
-            build?.artifacts?.applicationArchiveUrl ??
-            "";
-
-          if (!buildId) {
-            throw new Error(`Could not determine build ID from EAS output: ${raw}`);
-          }
-
-          if (!artifactUrl) {
-            throw new Error(`Could not determine artifact URL for build ${buildId}.`);
-          }
-
-          fs.appendFileSync(outputPath, `build_id=${buildId}\n`);
-          fs.appendFileSync(outputPath, `details_url=${detailsUrl}\n`);
-          fs.appendFileSync(outputPath, `artifact_url=${artifactUrl}\n`);
-          NODE
-
-      - name: Download AAB artifact
-        shell: bash
-        env:
-          ARTIFACT_URL: ${{ steps.eas_build.outputs.artifact_url }}
-        run: |
-          set -euo pipefail
-          mkdir -p dist
-          curl -fsSL "$ARTIFACT_URL" -o dist/vendor-map-app.aab
-
-      - name: Prepare GCS object metadata
-        id: gcs_meta
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          ref_slug="$(printf '%s' "${{ steps.context.outputs.requested_ref }}" | tr '/:@ ' '-' | tr -cd '[:alnum:]._-')"
-          if [ -z "$ref_slug" ]; then
-            ref_slug="manual"
-          fi
-
-          prefix="${GCS_PREFIX:-mobile-builds}"
-          prefix="${prefix#/}"
-          prefix="${prefix%/}"
-
-          artifact_file="vendor-map-app-${{ steps.context.outputs.app_version }}-${ref_slug}-${{ steps.context.outputs.short_sha }}-${{ steps.context.outputs.build_timestamp }}.aab"
-          object_path="android/aab/${{ steps.context.outputs.app_version }}/${artifact_file}"
-
-          if [ -n "$prefix" ]; then
-            object_path="${prefix}/${object_path}"
-          fi
-
-          echo "artifact_file=$artifact_file" >> "$GITHUB_OUTPUT"
-          echo "object_path=$object_path" >> "$GITHUB_OUTPUT"
-          echo "gs_uri=gs://${GCS_BUCKET}/${object_path}" >> "$GITHUB_OUTPUT"
-          echo "signed_url_duration=${GCS_SIGNED_URL_DURATION:-12h}" >> "$GITHUB_OUTPUT"
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-          project_id: ${{ vars.GCP_PROJECT_ID }}
-
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v3
-        with:
-          version: ">= 416.0.0"
-
-      - name: Upload AAB to GCS
-        shell: bash
-        run: |
-          set -euo pipefail
-          gcloud storage cp dist/vendor-map-app.aab "${{ steps.gcs_meta.outputs.gs_uri }}"
-
-      - name: Generate signed download URL
-        id: gcs_signed_url
-        shell: bash
-        run: |
-          set -euo pipefail
-          signed_url="$(
-            gcloud storage sign-url "${{ steps.gcs_meta.outputs.gs_uri }}" \
-              --duration="${{ steps.gcs_meta.outputs.signed_url_duration }}" \
-              --format='value(signed_url)'
-          )"
-          echo "signed_url=$signed_url" >> "$GITHUB_OUTPUT"
-
-      - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-aab-${{ steps.context.outputs.commit_sha }}
-          path: dist/vendor-map-app.aab
-          if-no-files-found: error
-
-      - name: Write job summary
-        shell: bash
-        run: |
-          {
-            echo "## Android AAB build"
-            echo ""
-            echo "- Profile: \`production-aab\`"
-            echo "- Requested ref: \`${{ inputs.ref || github.ref_name }}\`"
-            echo "- Checked out commit: \`${{ steps.context.outputs.commit_sha }}\`"
-            echo "- App version: \`${{ steps.context.outputs.app_version }}\`"
-            echo "- EAS build ID: \`${{ steps.eas_build.outputs.build_id }}\`"
-            echo "- EAS build details: ${{ steps.eas_build.outputs.details_url }}"
-            echo "- GitHub artifact: \`android-aab-${{ steps.context.outputs.commit_sha }}\`"
-            echo "- GCS object: \`${{ steps.gcs_meta.outputs.gs_uri }}\`"
-            echo "- Signed URL (${{ steps.gcs_meta.outputs.signed_url_duration }}): ${{ steps.gcs_signed_url.outputs.signed_url }}"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -7,252 +7,33 @@ on:
         description: "Git ref to build. Leave blank to use the selected branch or tag."
         required: false
         type: string
-
-permissions:
-  contents: read
-  id-token: write
+      generate_signed_url:
+        description: "Generate a signed download URL artifact. The URL will not be written to the job summary."
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
-    name: Build APK on EAS
-    runs-on: ubuntu-latest
-    env:
+    uses: ./.github/workflows/_android-build.yml
+    with:
+      ref: ${{ inputs.ref }}
+      build_name: APK
+      build_profile: preview-apk
+      artifact_extension: apk
+      artifact_subdir: apk
+      generate_signed_url: ${{ inputs.generate_signed_url }}
+      gcs_bucket: ${{ vars.GCS_BUCKET }}
+      gcs_prefix: ${{ vars.GCS_PREFIX }}
+      gcs_signed_url_duration: ${{ vars.GCS_SIGNED_URL_DURATION }}
+      gcp_workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      gcp_service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      gcp_project_id: ${{ vars.GCP_PROJECT_ID }}
+      expo_public_debug_logs: ${{ vars.EXPO_PUBLIC_DEBUG_LOGS }}
+    secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
       EXPO_PUBLIC_API_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_BASE_URL }}
       EXPO_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID }}
       EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS }}
       EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID }}
-      EXPO_PUBLIC_DEBUG_LOGS: ${{ secrets.EXPO_PUBLIC_DEBUG_LOGS }}
-      GCS_BUCKET: ${{ vars.GCS_BUCKET }}
-      GCS_PREFIX: ${{ vars.GCS_PREFIX }}
-      GCS_SIGNED_URL_DURATION: ${{ vars.GCS_SIGNED_URL_DURATION }}
-      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
-      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
-    steps:
-      - name: Check required GitHub secrets
-        shell: bash
-        run: |
-          set -euo pipefail
-          missing=0
-
-          for name in \
-            EXPO_TOKEN \
-            EXPO_PROJECT_ID \
-            EXPO_PUBLIC_API_BASE_URL \
-            EXPO_PUBLIC_GOOGLE_CLIENT_ID \
-            EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS \
-            EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID
-          do
-            if [ -z "${!name:-}" ]; then
-              echo "::error title=Missing secret::GitHub Actions secret '$name' is required."
-              missing=1
-            fi
-          done
-
-          if [ -z "${GCS_BUCKET:-}" ]; then
-            echo "::error title=Missing variable::GitHub Actions variable 'GCS_BUCKET' is required."
-            missing=1
-          fi
-
-          if [ -z "${GCP_WORKLOAD_IDENTITY_PROVIDER:-}" ]; then
-            echo "::error title=Missing variable::GitHub Actions variable 'GCP_WORKLOAD_IDENTITY_PROVIDER' is required."
-            missing=1
-          fi
-
-          if [ -z "${GCP_SERVICE_ACCOUNT:-}" ]; then
-            echo "::error title=Missing variable::GitHub Actions variable 'GCP_SERVICE_ACCOUNT' is required."
-            missing=1
-          fi
-
-          if [ "$missing" -ne 0 ]; then
-            echo "Missing one or more required GitHub Actions secrets or variables." >&2
-            exit 1
-          fi
-
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ inputs.ref || github.ref }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Setup Expo and EAS
-        uses: expo/expo-github-action@v8
-        with:
-          eas-version: latest
-          token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Resolve build context
-        id: context
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
-          echo "requested_ref=${{ inputs.ref || github.ref_name }}" >> "$GITHUB_OUTPUT"
-          echo "app_version=$(node -p "require('./app.json').expo.version")" >> "$GITHUB_OUTPUT"
-          echo "build_timestamp=$(date -u +%Y%m%dT%H%M%SZ)" >> "$GITHUB_OUTPUT"
-
-      - name: Validate Expo config for CI
-        shell: bash
-        run: |
-          set -euo pipefail
-          node - <<'NODE'
-          const loadConfig = require("./app.config.js");
-          const config = typeof loadConfig === "function" ? loadConfig() : loadConfig;
-          const projectId = config?.extra?.eas?.projectId;
-
-          if (!projectId) {
-            console.error(
-              "Missing EAS project ID. Set EXPO_PROJECT_ID in GitHub Secrets or expo.extra.eas.projectId in Expo config."
-            );
-            process.exit(1);
-          }
-
-          console.log(`Using EAS project ID: ${projectId}`);
-          NODE
-
-      - name: Trigger EAS Android APK build
-        id: eas_build
-        shell: bash
-        run: |
-          set -euo pipefail
-          build_json="$RUNNER_TEMP/eas-build-apk.json"
-
-          eas build \
-            --platform android \
-            --profile preview-apk \
-            --non-interactive \
-            --wait \
-            --json \
-            > "$build_json"
-
-          node - "$build_json" "$GITHUB_OUTPUT" <<'NODE'
-          const fs = require("fs");
-          const [jsonPath, outputPath] = process.argv.slice(2);
-          const raw = fs.readFileSync(jsonPath, "utf8").trim();
-
-          if (!raw) {
-            throw new Error("EAS build returned empty JSON output.");
-          }
-
-          const parsed = JSON.parse(raw);
-          const build = Array.isArray(parsed) ? parsed[0] : parsed;
-          const buildId = build?.id;
-          const detailsUrl = build?.buildDetailsPageUrl ?? "";
-          const artifactUrl =
-            build?.artifacts?.buildUrl ??
-            build?.artifacts?.applicationArchiveUrl ??
-            "";
-
-          if (!buildId) {
-            throw new Error(`Could not determine build ID from EAS output: ${raw}`);
-          }
-
-          if (!artifactUrl) {
-            throw new Error(`Could not determine artifact URL for build ${buildId}.`);
-          }
-
-          fs.appendFileSync(outputPath, `build_id=${buildId}\n`);
-          fs.appendFileSync(outputPath, `details_url=${detailsUrl}\n`);
-          fs.appendFileSync(outputPath, `artifact_url=${artifactUrl}\n`);
-          NODE
-
-      - name: Download APK artifact
-        shell: bash
-        env:
-          ARTIFACT_URL: ${{ steps.eas_build.outputs.artifact_url }}
-        run: |
-          set -euo pipefail
-          mkdir -p dist
-          curl -fsSL "$ARTIFACT_URL" -o dist/vendor-map-app.apk
-
-      - name: Prepare GCS object metadata
-        id: gcs_meta
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          ref_slug="$(printf '%s' "${{ steps.context.outputs.requested_ref }}" | tr '/:@ ' '-' | tr -cd '[:alnum:]._-')"
-          if [ -z "$ref_slug" ]; then
-            ref_slug="manual"
-          fi
-
-          prefix="${GCS_PREFIX:-mobile-builds}"
-          prefix="${prefix#/}"
-          prefix="${prefix%/}"
-
-          artifact_file="vendor-map-app-${{ steps.context.outputs.app_version }}-${ref_slug}-${{ steps.context.outputs.short_sha }}-${{ steps.context.outputs.build_timestamp }}.apk"
-          object_path="android/apk/${{ steps.context.outputs.app_version }}/${artifact_file}"
-
-          if [ -n "$prefix" ]; then
-            object_path="${prefix}/${object_path}"
-          fi
-
-          echo "artifact_file=$artifact_file" >> "$GITHUB_OUTPUT"
-          echo "object_path=$object_path" >> "$GITHUB_OUTPUT"
-          echo "gs_uri=gs://${GCS_BUCKET}/${object_path}" >> "$GITHUB_OUTPUT"
-          echo "signed_url_duration=${GCS_SIGNED_URL_DURATION:-12h}" >> "$GITHUB_OUTPUT"
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
-        with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
-          project_id: ${{ vars.GCP_PROJECT_ID }}
-
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@v3
-        with:
-          version: ">= 416.0.0"
-
-      - name: Upload APK to GCS
-        shell: bash
-        run: |
-          set -euo pipefail
-          gcloud storage cp dist/vendor-map-app.apk "${{ steps.gcs_meta.outputs.gs_uri }}"
-
-      - name: Generate signed download URL
-        id: gcs_signed_url
-        shell: bash
-        run: |
-          set -euo pipefail
-          signed_url="$(
-            gcloud storage sign-url "${{ steps.gcs_meta.outputs.gs_uri }}" \
-              --duration="${{ steps.gcs_meta.outputs.signed_url_duration }}" \
-              --format='value(signed_url)'
-          )"
-          echo "signed_url=$signed_url" >> "$GITHUB_OUTPUT"
-
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-apk-${{ steps.context.outputs.commit_sha }}
-          path: dist/vendor-map-app.apk
-          if-no-files-found: error
-
-      - name: Write job summary
-        shell: bash
-        run: |
-          {
-            echo "## Android APK build"
-            echo ""
-            echo "- Profile: \`preview-apk\`"
-            echo "- Requested ref: \`${{ inputs.ref || github.ref_name }}\`"
-            echo "- Checked out commit: \`${{ steps.context.outputs.commit_sha }}\`"
-            echo "- App version: \`${{ steps.context.outputs.app_version }}\`"
-            echo "- EAS build ID: \`${{ steps.eas_build.outputs.build_id }}\`"
-            echo "- EAS build details: ${{ steps.eas_build.outputs.details_url }}"
-            echo "- GitHub artifact: \`android-apk-${{ steps.context.outputs.commit_sha }}\`"
-            echo "- GCS object: \`${{ steps.gcs_meta.outputs.gs_uri }}\`"
-            echo "- Signed URL (${{ steps.gcs_meta.outputs.signed_url_duration }}): ${{ steps.gcs_signed_url.outputs.signed_url }}"
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-android-apk.yml
+++ b/.github/workflows/build-android-apk.yml
@@ -1,0 +1,258 @@
+name: Build Android APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build. Leave blank to use the selected branch or tag."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build APK on EAS
+    runs-on: ubuntu-latest
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      EXPO_PROJECT_ID: ${{ secrets.EXPO_PROJECT_ID }}
+      EXPO_PUBLIC_API_BASE_URL: ${{ secrets.EXPO_PUBLIC_API_BASE_URL }}
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID }}
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS }}
+      EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID: ${{ secrets.EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID }}
+      EXPO_PUBLIC_DEBUG_LOGS: ${{ secrets.EXPO_PUBLIC_DEBUG_LOGS }}
+      GCS_BUCKET: ${{ vars.GCS_BUCKET }}
+      GCS_PREFIX: ${{ vars.GCS_PREFIX }}
+      GCS_SIGNED_URL_DURATION: ${{ vars.GCS_SIGNED_URL_DURATION }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_SERVICE_ACCOUNT: ${{ vars.GCP_SERVICE_ACCOUNT }}
+      GCP_PROJECT_ID: ${{ vars.GCP_PROJECT_ID }}
+    steps:
+      - name: Check required GitHub secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+
+          for name in \
+            EXPO_TOKEN \
+            EXPO_PROJECT_ID \
+            EXPO_PUBLIC_API_BASE_URL \
+            EXPO_PUBLIC_GOOGLE_CLIENT_ID \
+            EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS \
+            EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "::error title=Missing secret::GitHub Actions secret '$name' is required."
+              missing=1
+            fi
+          done
+
+          if [ -z "${GCS_BUCKET:-}" ]; then
+            echo "::error title=Missing variable::GitHub Actions variable 'GCS_BUCKET' is required."
+            missing=1
+          fi
+
+          if [ -z "${GCP_WORKLOAD_IDENTITY_PROVIDER:-}" ]; then
+            echo "::error title=Missing variable::GitHub Actions variable 'GCP_WORKLOAD_IDENTITY_PROVIDER' is required."
+            missing=1
+          fi
+
+          if [ -z "${GCP_SERVICE_ACCOUNT:-}" ]; then
+            echo "::error title=Missing variable::GitHub Actions variable 'GCP_SERVICE_ACCOUNT' is required."
+            missing=1
+          fi
+
+          if [ "$missing" -ne 0 ]; then
+            echo "Missing one or more required GitHub Actions secrets or variables." >&2
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Setup Expo and EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve build context
+        id: context
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "requested_ref=${{ inputs.ref || github.ref_name }}" >> "$GITHUB_OUTPUT"
+          echo "app_version=$(node -p "require('./app.json').expo.version")" >> "$GITHUB_OUTPUT"
+          echo "build_timestamp=$(date -u +%Y%m%dT%H%M%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Expo config for CI
+        shell: bash
+        run: |
+          set -euo pipefail
+          node - <<'NODE'
+          const loadConfig = require("./app.config.js");
+          const config = typeof loadConfig === "function" ? loadConfig() : loadConfig;
+          const projectId = config?.extra?.eas?.projectId;
+
+          if (!projectId) {
+            console.error(
+              "Missing EAS project ID. Set EXPO_PROJECT_ID in GitHub Secrets or expo.extra.eas.projectId in Expo config."
+            );
+            process.exit(1);
+          }
+
+          console.log(`Using EAS project ID: ${projectId}`);
+          NODE
+
+      - name: Trigger EAS Android APK build
+        id: eas_build
+        shell: bash
+        run: |
+          set -euo pipefail
+          build_json="$RUNNER_TEMP/eas-build-apk.json"
+
+          eas build \
+            --platform android \
+            --profile preview-apk \
+            --non-interactive \
+            --wait \
+            --json \
+            > "$build_json"
+
+          node - "$build_json" "$GITHUB_OUTPUT" <<'NODE'
+          const fs = require("fs");
+          const [jsonPath, outputPath] = process.argv.slice(2);
+          const raw = fs.readFileSync(jsonPath, "utf8").trim();
+
+          if (!raw) {
+            throw new Error("EAS build returned empty JSON output.");
+          }
+
+          const parsed = JSON.parse(raw);
+          const build = Array.isArray(parsed) ? parsed[0] : parsed;
+          const buildId = build?.id;
+          const detailsUrl = build?.buildDetailsPageUrl ?? "";
+          const artifactUrl =
+            build?.artifacts?.buildUrl ??
+            build?.artifacts?.applicationArchiveUrl ??
+            "";
+
+          if (!buildId) {
+            throw new Error(`Could not determine build ID from EAS output: ${raw}`);
+          }
+
+          if (!artifactUrl) {
+            throw new Error(`Could not determine artifact URL for build ${buildId}.`);
+          }
+
+          fs.appendFileSync(outputPath, `build_id=${buildId}\n`);
+          fs.appendFileSync(outputPath, `details_url=${detailsUrl}\n`);
+          fs.appendFileSync(outputPath, `artifact_url=${artifactUrl}\n`);
+          NODE
+
+      - name: Download APK artifact
+        shell: bash
+        env:
+          ARTIFACT_URL: ${{ steps.eas_build.outputs.artifact_url }}
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          curl -fsSL "$ARTIFACT_URL" -o dist/vendor-map-app.apk
+
+      - name: Prepare GCS object metadata
+        id: gcs_meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ref_slug="$(printf '%s' "${{ steps.context.outputs.requested_ref }}" | tr '/:@ ' '-' | tr -cd '[:alnum:]._-')"
+          if [ -z "$ref_slug" ]; then
+            ref_slug="manual"
+          fi
+
+          prefix="${GCS_PREFIX:-mobile-builds}"
+          prefix="${prefix#/}"
+          prefix="${prefix%/}"
+
+          artifact_file="vendor-map-app-${{ steps.context.outputs.app_version }}-${ref_slug}-${{ steps.context.outputs.short_sha }}-${{ steps.context.outputs.build_timestamp }}.apk"
+          object_path="android/apk/${{ steps.context.outputs.app_version }}/${artifact_file}"
+
+          if [ -n "$prefix" ]; then
+            object_path="${prefix}/${object_path}"
+          fi
+
+          echo "artifact_file=$artifact_file" >> "$GITHUB_OUTPUT"
+          echo "object_path=$object_path" >> "$GITHUB_OUTPUT"
+          echo "gs_uri=gs://${GCS_BUCKET}/${object_path}" >> "$GITHUB_OUTPUT"
+          echo "signed_url_duration=${GCS_SIGNED_URL_DURATION:-12h}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          project_id: ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v3
+        with:
+          version: ">= 416.0.0"
+
+      - name: Upload APK to GCS
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud storage cp dist/vendor-map-app.apk "${{ steps.gcs_meta.outputs.gs_uri }}"
+
+      - name: Generate signed download URL
+        id: gcs_signed_url
+        shell: bash
+        run: |
+          set -euo pipefail
+          signed_url="$(
+            gcloud storage sign-url "${{ steps.gcs_meta.outputs.gs_uri }}" \
+              --duration="${{ steps.gcs_meta.outputs.signed_url_duration }}" \
+              --format='value(signed_url)'
+          )"
+          echo "signed_url=$signed_url" >> "$GITHUB_OUTPUT"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-apk-${{ steps.context.outputs.commit_sha }}
+          path: dist/vendor-map-app.apk
+          if-no-files-found: error
+
+      - name: Write job summary
+        shell: bash
+        run: |
+          {
+            echo "## Android APK build"
+            echo ""
+            echo "- Profile: \`preview-apk\`"
+            echo "- Requested ref: \`${{ inputs.ref || github.ref_name }}\`"
+            echo "- Checked out commit: \`${{ steps.context.outputs.commit_sha }}\`"
+            echo "- App version: \`${{ steps.context.outputs.app_version }}\`"
+            echo "- EAS build ID: \`${{ steps.eas_build.outputs.build_id }}\`"
+            echo "- EAS build details: ${{ steps.eas_build.outputs.details_url }}"
+            echo "- GitHub artifact: \`android-apk-${{ steps.context.outputs.commit_sha }}\`"
+            echo "- GCS object: \`${{ steps.gcs_meta.outputs.gs_uri }}\`"
+            echo "- Signed URL (${{ steps.gcs_meta.outputs.signed_url_duration }}): ${{ steps.gcs_signed_url.outputs.signed_url }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ yarn-error.*
 # macOS
 .DS_Store
 *.pem
+gha-creds-*.json
 
 # local env files
 .env*.local

--- a/app.config.js
+++ b/app.config.js
@@ -1,0 +1,12 @@
+const { expo } = require("./app.json");
+
+module.exports = () => ({
+  ...expo,
+  extra: {
+    ...(expo.extra ?? {}),
+    eas: {
+      ...(expo.extra?.eas ?? {}),
+      projectId: process.env.EXPO_PROJECT_ID ?? expo.extra?.eas?.projectId,
+    },
+  },
+});

--- a/docs/android-build-cicd.md
+++ b/docs/android-build-cicd.md
@@ -4,13 +4,16 @@ This repository includes two manually triggered GitHub Actions workflows for And
 
 - `Build Android APK`: generates a directly installable `.apk` for internal testing.
 - `Build Android AAB`: generates a `.aab` for store-oriented release workflows.
-- Both workflows also upload the final binary to Google Cloud Storage and generate a signed download URL.
+- Both workflows call the same reusable workflow so the actual CI logic lives in one place.
+- Both workflows upload the final binary to Google Cloud Storage.
+- Signed URLs are optional and are not written into the job summary.
 - Google Cloud authentication is configured with Workload Identity Federation instead of a long-lived service account key.
 
 ## Files added
 
 - `.github/workflows/build-android-apk.yml`
 - `.github/workflows/build-android-aab.yml`
+- `.github/workflows/_android-build.yml`
 - `eas.json`
 - `app.config.js`
 
@@ -52,7 +55,6 @@ Configure these repository secrets in GitHub:
 - `EXPO_PUBLIC_GOOGLE_CLIENT_ID`
 - `EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS`
 - `EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID`
-- `EXPO_PUBLIC_DEBUG_LOGS` (optional)
 
 `EXPO_PROJECT_ID` is read by `app.config.js` and injected into Expo config at build time. This keeps the repository free of a hard-coded EAS project ID while still allowing CI builds to resolve the project in non-interactive mode.
 
@@ -66,6 +68,7 @@ Configure these repository variables in GitHub:
 - `GCS_BUCKET`
 - `GCS_PREFIX` (optional, defaults to `mobile-builds`)
 - `GCS_SIGNED_URL_DURATION` (optional, defaults to `12h`)
+- `EXPO_PUBLIC_DEBUG_LOGS` (optional)
 
 Example object paths:
 
@@ -99,6 +102,7 @@ At minimum, grant bucket-level access equivalent to:
 For Workload Identity Federation, also allow the GitHub repository to impersonate the service account:
 
 - Grant `roles/iam.workloadIdentityUser` on the service account to the GitHub principal set for `slighter12/vendor-map-app`
+- Grant `roles/iam.serviceAccountTokenCreator` on the service account if you want the workflow to generate signed URLs
 
 Recommended Google Cloud setup commands:
 
@@ -168,16 +172,22 @@ Both workflows:
 
 - are triggered manually with `workflow_dispatch`
 - accept an optional `ref` input
-- install dependencies with `npm ci`
-- authenticate using `expo/expo-github-action`
-- authenticate to Google Cloud with `google-github-actions/auth` using Workload Identity Federation
-- fail early when required GitHub secrets are missing
-- run `eas build --platform android --non-interactive --wait --json`
-- download the resulting EAS artifact
-- upload it to Google Cloud Storage
-- generate a signed GCS download URL
-- keep a copy as a GitHub Actions artifact
-- write the build profile, commit SHA, app version, EAS build URL, GCS object path, and signed URL into the job summary
+- accept a `generate_signed_url` boolean input
+- delegate the actual build logic to the reusable workflow at `.github/workflows/_android-build.yml`
+
+The reusable workflow:
+
+- installs dependencies with `npm ci`
+- uses `actions/checkout@v4` and `actions/setup-node@v4`
+- pins EAS CLI to `18.4.0`
+- authenticates to Google Cloud with `google-github-actions/auth` using Workload Identity Federation
+- fails early when required GitHub secrets or variables are missing
+- runs `eas build --platform android --non-interactive --wait --json`
+- downloads the resulting EAS artifact
+- uploads it to Google Cloud Storage
+- optionally generates a signed GCS download URL
+- keeps a copy as a GitHub Actions artifact
+- writes the build profile, commit SHA, app version, EAS build URL, and GCS object path into the job summary
 
 ## Running the workflows
 
@@ -187,8 +197,9 @@ From GitHub:
 2. Choose either `Build Android APK` or `Build Android AAB`.
 3. Click `Run workflow`.
 4. Optionally provide a branch, tag, or commit in `ref`.
-5. Open the job summary to copy the signed GCS download URL.
-6. Or download the backup copy from the GitHub Actions artifact section.
+5. Leave `generate_signed_url` disabled unless you explicitly need a signed link.
+6. Download the app package from the GitHub Actions artifact section, or copy the `gs://...` path from the job summary.
+7. If you enabled `generate_signed_url`, download the URL from the extra signed-URL artifact rather than the job summary.
 
 ## Notes and limitations
 
@@ -199,6 +210,7 @@ From GitHub:
 - If GCS authentication fails, verify the Workload Identity Provider path, service account email, IAM bindings, and that GitHub Actions has `id-token: write`.
 - Google notes that Workload Identity Pool / Provider / IAM changes can take up to about 5 minutes to propagate. If setup is fresh, wait and rerun once before troubleshooting deeper.
 - With Workload Identity Federation, `gcloud storage sign-url` uses service account-based signing without a private key file, so practical signed URL duration is capped at 12 hours. Use a shorter duration or switch distribution strategy if you need longer-lived links.
+- Signed URL generation is best-effort. If it fails, the build still succeeds, the GCS upload remains available, and the job summary points you back to IAM/signBlob troubleshooting instead of exposing a partial URL.
 
 ## References
 
@@ -210,3 +222,4 @@ From GitHub:
 - [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
 - [Cloud Storage signed URLs](https://cloud.google.com/storage/docs/access-control/signed-urls)
 - [gcloud storage sign-url](https://cloud.google.com/sdk/gcloud/reference/storage/sign-url)
+- [Reusable workflows](https://docs.github.com/en/actions/sharing-automations/reusing-workflows)

--- a/docs/android-build-cicd.md
+++ b/docs/android-build-cicd.md
@@ -1,0 +1,212 @@
+# Android CI/CD with GitHub Actions and EAS Build
+
+This repository includes two manually triggered GitHub Actions workflows for Android builds:
+
+- `Build Android APK`: generates a directly installable `.apk` for internal testing.
+- `Build Android AAB`: generates a `.aab` for store-oriented release workflows.
+- Both workflows also upload the final binary to Google Cloud Storage and generate a signed download URL.
+- Google Cloud authentication is configured with Workload Identity Federation instead of a long-lived service account key.
+
+## Files added
+
+- `.github/workflows/build-android-apk.yml`
+- `.github/workflows/build-android-aab.yml`
+- `eas.json`
+- `app.config.js`
+
+## Prerequisites
+
+Before these workflows can succeed in CI, finish the Expo / EAS bootstrap locally at least once.
+
+1. Install dependencies:
+
+   ```bash
+   npm ci
+   ```
+
+2. Log in to Expo / EAS:
+
+   ```bash
+   npx eas-cli@latest login
+   ```
+
+3. Initialize or link the project on EAS and complete one successful Android build locally:
+
+   ```bash
+   npx eas-cli@latest build --platform android --profile preview-apk
+   ```
+
+This first successful local build is important because EAS needs to complete the non-interactive setup ahead of CI:
+
+- Create or link the EAS project
+- Provision Android signing credentials
+- Confirm the build profiles work with the current app config
+
+## Required GitHub Actions secrets
+
+Configure these repository secrets in GitHub:
+
+- `EXPO_TOKEN`
+- `EXPO_PROJECT_ID`
+- `EXPO_PUBLIC_API_BASE_URL`
+- `EXPO_PUBLIC_GOOGLE_CLIENT_ID`
+- `EXPO_PUBLIC_GOOGLE_CLIENT_ID_IOS`
+- `EXPO_PUBLIC_GOOGLE_CLIENT_ID_ANDROID`
+- `EXPO_PUBLIC_DEBUG_LOGS` (optional)
+
+`EXPO_PROJECT_ID` is read by `app.config.js` and injected into Expo config at build time. This keeps the repository free of a hard-coded EAS project ID while still allowing CI builds to resolve the project in non-interactive mode.
+
+## Required GitHub Actions variables
+
+Configure these repository variables in GitHub:
+
+- `GCP_WORKLOAD_IDENTITY_PROVIDER`
+- `GCP_SERVICE_ACCOUNT`
+- `GCP_PROJECT_ID` (recommended)
+- `GCS_BUCKET`
+- `GCS_PREFIX` (optional, defaults to `mobile-builds`)
+- `GCS_SIGNED_URL_DURATION` (optional, defaults to `12h`)
+
+Example object paths:
+
+- `gs://my-build-bucket/mobile-builds/android/apk/1.0.0/vendor-map-app-1.0.0-main-abc1234-20260331T040000Z.apk`
+- `gs://my-build-bucket/mobile-builds/android/aab/1.0.0/vendor-map-app-1.0.0-main-abc1234-20260331T040000Z.aab`
+
+## Required EAS configuration
+
+GitHub secrets alone are not enough for remote Expo builds.
+
+Because EAS Build runs on Expo's infrastructure, the `EXPO_PUBLIC_*` variables used by the app should also be defined in the EAS project environment:
+
+- `preview` environment for `preview-apk`
+- `production` environment for `production-aab`
+
+Recommended setup:
+
+- Keep `EXPO_TOKEN` and `EXPO_PROJECT_ID` in GitHub Secrets
+- Mirror the `EXPO_PUBLIC_*` values in both GitHub Secrets and EAS environments
+- Keep Android signing credentials managed by EAS
+- Use Workload Identity Federation for GCS upload access instead of storing a JSON key in GitHub
+
+## Required Google Cloud permissions
+
+The Google Cloud service account referenced by `GCP_SERVICE_ACCOUNT` should have permission to upload objects into the target bucket and generate signed URLs for the uploaded objects.
+
+At minimum, grant bucket-level access equivalent to:
+
+- `Storage Object Admin` on the target bucket
+
+For Workload Identity Federation, also allow the GitHub repository to impersonate the service account:
+
+- Grant `roles/iam.workloadIdentityUser` on the service account to the GitHub principal set for `slighter12/vendor-map-app`
+
+Recommended Google Cloud setup commands:
+
+```bash
+export PROJECT_ID="your-gcp-project-id"
+export PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)')"
+export GITHUB_ORG="slighter12"
+export REPO="slighter12/vendor-map-app"
+export POOL_ID="github"
+export PROVIDER_ID="vendor-map-app"
+export SERVICE_ACCOUNT_ID="github-actions-vendor-map-app"
+export SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT_ID}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+gcloud services enable iamcredentials.googleapis.com sts.googleapis.com
+
+gcloud iam service-accounts create "$SERVICE_ACCOUNT_ID" \
+  --project="$PROJECT_ID"
+
+gcloud iam workload-identity-pools create "$POOL_ID" \
+  --project="$PROJECT_ID" \
+  --location="global" \
+  --display-name="GitHub Actions Pool"
+
+gcloud iam workload-identity-pools providers create-oidc "$PROVIDER_ID" \
+  --project="$PROJECT_ID" \
+  --location="global" \
+  --workload-identity-pool="$POOL_ID" \
+  --display-name="vendor-map-app provider" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.actor=assertion.actor,attribute.repository=assertion.repository,attribute.repository_owner=assertion.repository_owner" \
+  --attribute-condition="assertion.repository_owner == '${GITHUB_ORG}'" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+
+WORKLOAD_IDENTITY_POOL_NAME="$(gcloud iam workload-identity-pools describe "$POOL_ID" \
+  --project="$PROJECT_ID" \
+  --location="global" \
+  --format='value(name)')"
+
+gcloud iam service-accounts add-iam-policy-binding "$SERVICE_ACCOUNT_EMAIL" \
+  --project="$PROJECT_ID" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="principalSet://iam.googleapis.com/${WORKLOAD_IDENTITY_POOL_NAME}/attribute.repository/${REPO}"
+
+gcloud storage buckets add-iam-policy-binding "gs://YOUR_GCS_BUCKET" \
+  --member="serviceAccount:${SERVICE_ACCOUNT_EMAIL}" \
+  --role="roles/storage.objectAdmin"
+
+gcloud iam workload-identity-pools providers describe "$PROVIDER_ID" \
+  --project="$PROJECT_ID" \
+  --location="global" \
+  --workload-identity-pool="$POOL_ID" \
+  --format='value(name)'
+```
+
+Use the last command output as `GCP_WORKLOAD_IDENTITY_PROVIDER`, and set `GCP_SERVICE_ACCOUNT` to the service account email.
+
+The workflow authenticates via GitHub OIDC, impersonates the service account through Workload Identity Federation, uploads the binary, and then signs a time-limited download URL using the same short-lived credentials.
+
+If you need to create environment variables on EAS, use either the Expo dashboard or EAS CLI. Example:
+
+```bash
+npx eas-cli@latest env:create --name EXPO_PUBLIC_API_BASE_URL --value https://api.example.com --environment preview --visibility plaintext
+```
+
+## Workflow behavior
+
+Both workflows:
+
+- are triggered manually with `workflow_dispatch`
+- accept an optional `ref` input
+- install dependencies with `npm ci`
+- authenticate using `expo/expo-github-action`
+- authenticate to Google Cloud with `google-github-actions/auth` using Workload Identity Federation
+- fail early when required GitHub secrets are missing
+- run `eas build --platform android --non-interactive --wait --json`
+- download the resulting EAS artifact
+- upload it to Google Cloud Storage
+- generate a signed GCS download URL
+- keep a copy as a GitHub Actions artifact
+- write the build profile, commit SHA, app version, EAS build URL, GCS object path, and signed URL into the job summary
+
+## Running the workflows
+
+From GitHub:
+
+1. Open the `Actions` tab.
+2. Choose either `Build Android APK` or `Build Android AAB`.
+3. Click `Run workflow`.
+4. Optionally provide a branch, tag, or commit in `ref`.
+5. Open the job summary to copy the signed GCS download URL.
+6. Or download the backup copy from the GitHub Actions artifact section.
+
+## Notes and limitations
+
+- `APK` is intended for direct installation on Android devices.
+- `AAB` is not a directly installable file and is meant for Play Store or store-adjacent distribution workflows.
+- iOS is intentionally not wired into CI yet because Apple credentials and signing repair paths are not configured in this repository.
+- If CI fails with credential-related EAS errors, repair or re-create Android credentials locally first and rerun the workflow.
+- If GCS authentication fails, verify the Workload Identity Provider path, service account email, IAM bindings, and that GitHub Actions has `id-token: write`.
+- Google notes that Workload Identity Pool / Provider / IAM changes can take up to about 5 minutes to propagate. If setup is fresh, wait and rerun once before troubleshooting deeper.
+- With Workload Identity Federation, `gcloud storage sign-url` uses service account-based signing without a private key file, so practical signed URL duration is capped at 12 hours. Use a shorter duration or switch distribution strategy if you need longer-lived links.
+
+## References
+
+- [Trigger builds from CI](https://docs.expo.dev/build/building-on-ci/)
+- [Configure EAS Build with eas.json](https://docs.expo.dev/build/eas-json/)
+- [Environment variables in EAS](https://docs.expo.dev/eas/environment-variables/)
+- [google-github-actions/auth](https://github.com/google-github-actions/auth)
+- [google-github-actions/setup-gcloud](https://github.com/google-github-actions/setup-gcloud)
+- [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation)
+- [Cloud Storage signed URLs](https://cloud.google.com/storage/docs/access-control/signed-urls)
+- [gcloud storage sign-url](https://cloud.google.com/sdk/gcloud/reference/storage/sign-url)

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,27 @@
+{
+  "cli": {
+    "version": ">= 18.4.0",
+    "promptToConfigurePushNotifications": false
+  },
+  "build": {
+    "base": {
+      "credentialsSource": "remote",
+      "android": {
+        "image": "latest"
+      }
+    },
+    "preview-apk": {
+      "extends": "base",
+      "distribution": "internal",
+      "environment": "preview",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production-aab": {
+      "extends": "base",
+      "distribution": "store",
+      "environment": "production"
+    }
+  }
+}


### PR DESCRIPTION
- add manual EAS workflows for APK and AAB builds
- upload build outputs to GCS with signed URLs
- document WIF, EAS, and GCS setup requirements